### PR TITLE
fix minor typos and improve Exclude selector BNF

### DIFF
--- a/interest.rst
+++ b/interest.rst
@@ -78,7 +78,10 @@ Exclude
 
 ::
 
-    Exclude ::= EXCLUDE-TYPE TLV-LENGTH Any? (NameComponent (Any)?)+
+    Exclude ::= EXCLUDE-TYPE TLV-LENGTH AnyLeading? (NameComponent | AnyBetween)* AnyTrailing?
+    AnyLeading ::= Any NameComponent
+    AnyBetween ::= NameComponent Any NameComponent
+    AnyTrailing ::= NameComponent Any
     Any ::= ANY-TYPE TLV-LENGTH(=0)
 
 The ``Exclude`` selectors allow requesters to specify list and/or ranges of name components that MUST NOT appear as a continuation of the Name prefix in the responding Data packet to the Interest.

--- a/interest.rst
+++ b/interest.rst
@@ -81,14 +81,14 @@ Exclude
     Exclude ::= EXCLUDE-TYPE TLV-LENGTH Any? (NameComponent (Any)?)+
     Any ::= ANY-TYPE TLV-LENGTH(=0)
 
-The ``Exclude`` selectors allows requester to specify list and/or ranges of names components that MUST NOT appear as a continuation of the Name prefix in the responding Data packet to the Interest.
+The ``Exclude`` selectors allow requesters to specify list and/or ranges of name components that MUST NOT appear as a continuation of the Name prefix in the responding Data packet to the Interest.
 For example, if Interest is expressed for ``/ndn/edu`` and Exclude specifies one name component ``ucla``, then neither data producer nor conforming NDN routers are allowed to return any Data packet that has prefix ``/ndn/edu/ucla``.
 
 Exclude filter applies only to a name component of the Data packet name that is located at a position that numerically equals to the number of name components in the Interest packet, assuming 0 is the first name component.
 
 The Components in the exclusion list MUST occur in strictly increasing order according to the canonical NDN name component ordering (:ref:`Name Section<name>`), with optional leading, trailing, and interleaved ``Any`` components. The following defines processing of ``Any`` components:
 
-- If none of the ``Any`` components are specified, the filter excludes only to the names specified in the Exclude list.
+- If none of the ``Any`` components are specified, the filter excludes only the names specified in the Exclude list.
 
 - If a leading ``Any`` component is specified, then the filter excludes all names that are smaller or equal (in NDN name component canonical ordering) to the first NameComponent in the Exclude list.
 

--- a/intro.rst
+++ b/intro.rst
@@ -1,7 +1,7 @@
 Introduction
 ------------
 
-This version 0.1 specification aims to describe the NDN packet format only, a much narrower scope than a full NDN protocol specification. Our plan is to circulate and finalize the packet format first, then write down the full protocol specification. 
+This version specification aims to describe the NDN packet format only, a much narrower scope than a full NDN protocol specification. Our plan is to circulate and finalize the packet format first, then write down the full protocol specification. 
 
 In addition to this protocol specification draft, we are also in the process of putting out a set of technical memos that document our reasoning behind the design choices of important issues.  The first few to come out will address the following issues:
 

--- a/tlv.rst
+++ b/tlv.rst
@@ -119,7 +119,7 @@ Depending on the length value, a nonNegativeInteger is encoded as follows:
 
 - if the length is 8 (= value length is 8 octets), the nonNegativeInteger is encoded in 8 octets, in net byte-order.
 
-The following shows a few examples of TLVs that has nonNegativeInteger as their value component in hexadecimal format (where ``TT`` represents ``TLV-TYPE``, followed by the ``TLV-LENGTH``, then ``TLV-VALUE``)::
+The following shows a few examples of TLVs that have nonNegativeInteger as their value component in hexadecimal format (where ``TT`` represents ``TLV-TYPE``, followed by the ``TLV-LENGTH``, then ``TLV-VALUE``)::
 
     0     => TT0100
     1     => TT0101


### PR DESCRIPTION
This PR fixes minor typos and improves the BNF of the exclude selector.

The current BNF can generate words of the form:
`(A=Any, N=NameComponent)`

```
A N A
```

although this is prohibited by the text.

Furthermore, words that contain `N A N` shouldn't be prefixed and suffixed with an `A`, because `A N_1 A N_2 A ... N_x` is equivalent to `A N_x` and respectively `N_1 A N_2 A ... N_x A` is equivalent to `N_1 A`.

The proposed BNF only generates words of the form that do not contain `A N A N` and `N A N A`.
